### PR TITLE
Switching dependencies to zenohcpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,11 @@ jobs:
         run: |
           conan create --version 0.2.0 --build=missing up-conan-recipes/up-cpp/developer
 
-      - name: Build zenohc conan package
+      - name: Build zenohcpp conan package
         shell: bash
         run: |
-          conan create --version 0.11.0.3 up-conan-recipes/zenohc-tmp/prebuilt
+          conan create --version 0.11.0 up-conan-recipes/zenohc-tmp/prebuilt
+          conan create --version 0.11.0 up-conan-recipes/zenohcpp-tmp/from-source
 
       - name: Fetch up-transport-zenoh-cpp
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(protobuf REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(up-core-api REQUIRED)
 find_package(up-cpp REQUIRED)
-find_package(zenohc REQUIRED)
+find_package(zenohcpp REQUIRED)
 
 # TODO NEEDED?
 #add_definitions(-DSPDLOG_FMT_EXTERNAL)
@@ -41,7 +41,7 @@ target_include_directories(${PROJECT_NAME}
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 	$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-	${zenohc_INCLUDE_DIR}
+	${zenohcpp_INCLUDE_DIR}
 	${up-cpp_INCLUDE_DIR}
 	${up-core-api_INCLUDE_DIR}
 	${protobuf_INCLUDE_DIR}
@@ -51,7 +51,7 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
-	zenohc::lib
+	zenohcpp::lib
 	up-cpp::up-cpp
 	up-core-api::up-core-api
 	protobuf::libprotobuf

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 up-cpp/0.2.0
-zenohc/0.11.0.3
+zenohcpp/0.11.0
 # Should result in using the packages from up-cpp
 spdlog/[>=1.13.0]
 up-core-api/[>=1.5.8]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ function(add_coverage_test Name)
         up-core-api::up-core-api
         up-cpp::up-cpp
         up-cpp::up-transport-zenoh-cpp
-        zenohc::lib
+        zenohcpp::lib
         spdlog::spdlog
         protobuf::protobuf
         PRIVATE


### PR DESCRIPTION
The new implementation will use the C++ Zenoh library instead of the C library.

This is related to https://github.com/eclipse-uprotocol/up-conan-recipes/issues/12

Publishing in draft state until https://github.com/eclipse-uprotocol/up-conan-recipes/pull/13 is merged.