### PR TITLE
Update dependency to zenoh-cpp 1.0.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build zenohcpp conan package
         shell: bash
         run: |
-          conan create --version 1.0.0-rc5 up-conan-recipes/zenohc-tmp/prebuilt
-          conan create --version 1.0.0-rc5 up-conan-recipes/zenohcpp-tmp/from-source
+          conan create --version 1.0.0-rc6 up-conan-recipes/zenohc-tmp/prebuilt
+          conan create --version 1.0.0-rc6 up-conan-recipes/zenohcpp-tmp/from-source
 
       - name: Fetch up-transport-zenoh-cpp
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ from [up-cpp][cpp-api-repo].
 Using the recipes found in [up-conan-recipes][conan-recipe-repo], build these
 Conan packages:
 
-1. [up-core-api][spec-repo] - `conan create --version 1.6.0 --build=missing up-core-api/release`
-1. [up-cpp][cpp-api-repo] - `conan create --version 1.0.1-rc1 --build=missing up-cpp/release`
-2. [zenoh-c][zenoh-repo] - `conan create --version 0.11.0 zenoh-tmp/from-source`
+1. [up-core-api][spec-repo] - `conan create --version 1.6.0-alpha3 --build=missing up-core-api/release`
+1. [up-cpp][cpp-api-repo] - `conan create --version 1.0.1 --build=missing up-cpp/release`
+2. [zenoh-c][zenoh-repo] - `conan create --version 1.0.0-rc6 zenohc-tmp/prebuilt`
+2. [zenoh-c][zenoh-repo] - `conan create --version 1.0.0-rc6 zenohcpp-tmp/from-source`
 
 **NOTE:** all `conan` commands in this document use  Conan 2.x syntax. Please
 adjust accordingly when using Conan 1.x.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 up-cpp/[^1.0.1]
-zenohcpp/1.0.0-rc5
-zenohc/1.0.0-rc5
+zenohcpp/1.0.0-rc6
+zenohc/1.0.0-rc6
 spdlog/[~1.13]
 up-core-api/[~1.6, include_prerelease]
 protobuf/[~3.21]


### PR DESCRIPTION
Current uProtocol spec requires this release for compatibility. It corresponds to the zenoh rust core at 1.0.0-alpha6.

closes #108 