### PR TITLE
Align CI with up-cpp CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: ["**"]
   pull_request:
     branches: ["**"]
 
@@ -15,9 +15,20 @@ jobs:
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
+        with:
+          version: 2.3.2
 
-      - name: Create default Conan profile
-        run: conan profile detect
+      - name: Fetch up-transport-zenoh-cpp
+        uses: actions/checkout@v4
+        with:
+          path: up-transport-zenoh-cpp
+        
+      - name: Install conan CI profile
+        shell: bash
+        run: |
+          conan profile detect
+          cp up-transport-zenoh-cpp/.github/workflows/ci_conan_profile "$(conan profile path default)"
+          conan profile show 
 
       - name: Fetch up-core-api conan recipe
         uses: actions/checkout@v4
@@ -41,18 +52,14 @@ jobs:
           conan create --version 1.0.0-rc5 up-conan-recipes/zenohc-tmp/prebuilt
           conan create --version 1.0.0-rc5 up-conan-recipes/zenohcpp-tmp/from-source
 
-      - name: Fetch up-transport-zenoh-cpp
-        uses: actions/checkout@v4
-        with:
-          path: up-transport-zenoh-cpp
-
       - name: Build up-transport-zenoh-cpp with tests
         shell: bash
         run: |
           cd up-transport-zenoh-cpp
-          conan install . --deployer=full_deploy --build=missing
+          conan install --build=missing . --deployer=full_deploy 
           cmake --preset conan-release -DCMAKE_EXPORT_COMPILE_COMMANDS=yes
-          cmake --build --preset conan-release -- -j
+          cd build/Release
+          cmake --build . -- -j
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -120,6 +127,8 @@ jobs:
       - name: Install Conan
         id: conan
         uses: turtlebrowser/get-conan@main
+        with:
+          version: 2.3.2
 
       - name: Create default Conan profile
         run: conan profile detect
@@ -150,6 +159,8 @@ jobs:
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
           database: compile_commands.json
+          version: 17
+
 
       - name: Run linters on tests
         id: test-linter
@@ -162,12 +173,290 @@ jobs:
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
           database: compile_commands.json
+          version: 17
 
       - name: Report lint failure
         if: steps.source-linter.outputs.checks-failed > 0 || steps.test-linter.outputs.checks-failed > 0
         run: |
           exit 1
 
+  memcheck:
+      name: Run Valgrind Memcheck
+      runs-on: ubuntu-latest
+      needs: build
+
+      steps:
+        - name: Get build artifacts
+          uses: actions/download-artifact@v4
+          with:
+            name: build-artifacts
+            path: up-transport-zenoh-cpp 
+
+        - name: Install Valgrind
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y valgrind
+
+        - name: Run Valgrind Memcheck
+          continue-on-error: true
+          run: |
+            cd up-transport-zenoh-cpp/build/Release
+            touch valgrind_exclude_test_memcheck.txt
+            chmod +x bin/*
+            mkdir -p valgrind_logs
+            : > valgrind_logs/valgrind_memcheck_summary.log
+            declare -A EXCLUDE_TESTS
+            while IFS= read -r line; do
+              test_binary=$(echo $line | cut -d'.' -f1)
+              test_suite=$(echo $line | cut -d'.' -f2)
+              test_name=$(echo $line | cut -d'.' -f3)
+              if [[ -z "${EXCLUDE_TESTS["$test_binary"]}" ]]; then
+                EXCLUDE_TESTS["$test_binary"]="-"
+              else
+                EXCLUDE_TESTS["$test_binary"]+=":"
+              fi
+              EXCLUDE_TESTS["$test_binary"]+="$test_suite.$test_name"
+            done < valgrind_exclude_test_memcheck.txt
+
+            for test_binary in bin/*Test; do
+              test_binary_name=$(basename $test_binary)
+              echo "Running Valgrind on $test_binary_name"
+              if [[ -n "${EXCLUDE_TESTS[$test_binary_name]}" ]]; then
+                exclude_pattern="${EXCLUDE_TESTS[$test_binary_name]}"
+                valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --log-file="valgrind_logs/$test_binary_name.log" ./$test_binary --gtest_filter="$exclude_pattern" || true
+              else
+                valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --log-file="valgrind_logs/$test_binary_name.log" ./$test_binary || true
+              fi
+
+              cat "valgrind_logs/$test_binary_name.log" >> valgrind_logs/valgrind_complete_memcheck_log.log
+
+              if grep -q "ERROR SUMMARY: [^0]" "valgrind_logs/$test_binary_name.log"; then
+                echo "Valgrind errors found in $test_binary_name:"
+                grep -A1 "ERROR SUMMARY:" "valgrind_logs/$test_binary_name.log" >> valgrind_logs/valgrind_memcheck_summary.log
+                echo "Valgrind log for $test_binary_name:"
+                cat "valgrind_logs/$test_binary_name.log"
+                echo "------------------------"
+              fi
+            done
+            echo "Valgrind Memcheck Summary:"
+            cat valgrind_logs/valgrind_memcheck_summary.log
+
+        - name: Upload Valgrind Memcheck logs
+          uses: actions/upload-artifact@v4
+          if: success() || failure()
+          with:
+            name: valgrind-memcheck-log
+            path: up-transport-zenoh-cpp/build/Release/valgrind_logs/valgrind_complete_memcheck_log.log
+
+  threadcheck:
+    name: Run Valgrind ThreadCheck
+    runs-on: ubuntu-latest
+    needs: build
+  
+    steps:
+      - name: Get build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: up-transport-zenoh-cpp 
+  
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+  
+      - name: Run Valgrind ThreadCheck
+        continue-on-error: true
+        run: |
+          cd up-transport-zenoh-cpp/build/Release
+          touch valgrind_exclude_test_threadcheck.txt
+          chmod +x bin/*
+          mkdir -p valgrind_logs
+          : > valgrind_logs/valgrind_threadcheck_summary.log
+          : > valgrind_logs/valgrind_complete_threadcheck_log.log
+          declare -A EXCLUDE_TESTS
+          while IFS= read -r line; do
+            test_binary=$(echo $line | cut -d'.' -f1)
+            test_suite=$(echo $line | cut -d'.' -f2)
+            test_name=$(echo $line | cut -d'.' -f3)
+            if [[ -z "${EXCLUDE_TESTS["$test_binary"]}" ]]; then
+              EXCLUDE_TESTS["$test_binary"]="-"
+            else
+              EXCLUDE_TESTS["$test_binary"]+=":"
+            fi
+            EXCLUDE_TESTS["$test_binary"]+="$test_suite.$test_name"
+          done < valgrind_exclude_test_threadcheck.txt
+  
+          for test_binary in bin/*Test; do
+            test_binary_name=$(basename $test_binary)
+            echo "Running Valgrind ThreadCheck on $test_binary_name"
+            if [[ -n "${EXCLUDE_TESTS[$test_binary_name]}" ]]; then
+              exclude_pattern="${EXCLUDE_TESTS[$test_binary_name]}"
+              valgrind --tool=drd --log-file="valgrind_logs/$test_binary_name_threadcheck.log" ./$test_binary --gtest_filter="$exclude_pattern" || true
+            else
+              valgrind --tool=drd --log-file="valgrind_logs/$test_binary_name_threadcheck.log" ./$test_binary || true
+            fi
+  
+            cat "valgrind_logs/$test_binary_name_threadcheck.log" >> valgrind_logs/valgrind_complete_threadcheck_log.log
+  
+            if grep -q "ERROR SUMMARY: [^0]" "valgrind_logs/$test_binary_name_threadcheck.log"; then
+              echo "Valgrind ThreadCheck errors found in $test_binary_name:"
+              grep -A1 "ERROR SUMMARY:" "valgrind_logs/$test_binary_name_threadcheck.log" >> valgrind_logs/valgrind_threadcheck_summary.log
+              echo "Valgrind ThreadCheck log for $test_binary_name:"
+              cat "valgrind_logs/$test_binary_name_threadcheck.log"
+              echo "------------------------"
+            fi
+          done
+  
+          echo "Valgrind ThreadCheck Summary:"
+          cat valgrind_logs/valgrind_threadcheck_summary.log
+  
+      - name: Upload Valgrind ThreadCheck logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: valgrind-threadcheck-log
+          path: up-transport-zenoh-cpp/build/Release/valgrind_logs/valgrind_complete_threadcheck_log.log        
+          
+  helgrind:
+    name: Run Valgrind Helgrind
+    runs-on: ubuntu-latest
+    needs: build
+  
+    steps:
+      - name: Get build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: up-transport-zenoh-cpp 
+  
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+  
+      - name: Run Valgrind Helgrind
+        continue-on-error: true
+        run: |
+          cd up-transport-zenoh-cpp/build/Release
+          touch valgrind_exclude_test_helgrind.txt
+          chmod +x bin/*
+          mkdir -p valgrind_logs
+          : > valgrind_logs/valgrind_helgrind_summary.log
+          : > valgrind_logs/valgrind_complete_helgrind_log.log
+          declare -A EXCLUDE_TESTS
+          while IFS= read -r line; do
+            test_binary=$(echo $line | cut -d'.' -f1)
+            test_suite=$(echo $line | cut -d'.' -f2)
+            test_name=$(echo $line | cut -d'.' -f3)
+            if [[ -z "${EXCLUDE_TESTS["$test_binary"]}" ]]; then
+              EXCLUDE_TESTS["$test_binary"]="-"
+            else
+              EXCLUDE_TESTS["$test_binary"]+=":"
+            fi
+            EXCLUDE_TESTS["$test_binary"]+="$test_suite.$test_name"
+          done < valgrind_exclude_test_helgrind.txt
+  
+          for test_binary in bin/*Test; do
+            test_binary_name=$(basename $test_binary)
+            echo "Running Valgrind Helgrind on $test_binary_name"
+            if [[ -n "${EXCLUDE_TESTS[$test_binary_name]}" ]]; then
+              exclude_pattern="${EXCLUDE_TESTS[$test_binary_name]}"
+              valgrind --tool=helgrind --log-file="valgrind_logs/$test_binary_name_helgrind.log" ./$test_binary --gtest_filter="$exclude_pattern" || true
+            else
+              valgrind --tool=helgrind --log-file="valgrind_logs/$test_binary_name_helgrind.log" ./$test_binary || true
+            fi
+  
+            cat "valgrind_logs/$test_binary_name_helgrind.log" >> valgrind_logs/valgrind_complete_helgrind_log.log
+  
+            if grep -q "ERROR SUMMARY: [^0]" "valgrind_logs/$test_binary_name_helgrind.log"; then
+              echo "Valgrind Helgrind errors found in $test_binary_name:"
+              grep -A1 "ERROR SUMMARY:" "valgrind_logs/$test_binary_name_helgrind.log" >> valgrind_logs/valgrind_helgrind_summary.log
+              echo "Valgrind Helgrind log for $test_binary_name:"
+              cat "valgrind_logs/$test_binary_name_helgrind.log"
+              echo "------------------------"
+            fi
+          done
+  
+          echo "Valgrind Helgrind Summary:"
+          cat valgrind_logs/valgrind_helgrind_summary.log
+  
+      - name: Upload Valgrind Helgrind logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: valgrind-helgrind-log
+          path: up-transport-zenoh-cpp/build/Release/valgrind_logs/valgrind_complete_helgrind_log.log    
+          
+  dhat:
+    name: Run Valgrind DHAT
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Get build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: up-transport-zenoh-cpp
+
+      - name: Install Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+
+      - name: Run Valgrind DHAT
+        continue-on-error: true
+        run: |
+          cd up-transport-zenoh-cpp/build/Release
+          touch valgrind_exclude_test_dhat.txt
+          chmod +x bin/*
+          mkdir -p valgrind_logs
+          : > valgrind_logs/valgrind_dhat_summary.log
+          : > valgrind_logs/valgrind_complete_dhat_log.log
+          declare -A EXCLUDE_TESTS
+          while IFS= read -r line; do
+            test_binary=$(echo $line | cut -d'.' -f1)
+            test_suite=$(echo $line | cut -d'.' -f2)
+            test_name=$(echo $line | cut -d'.' -f3)
+            if [[ -z "${EXCLUDE_TESTS["$test_binary"]}" ]]; then
+              EXCLUDE_TESTS["$test_binary"]="-"
+            else
+              EXCLUDE_TESTS["$test_binary"]+=":"
+            fi
+            EXCLUDE_TESTS["$test_binary"]+="$test_suite.$test_name"
+          done < valgrind_exclude_test_dhat.txt
+
+          for test_binary in bin/*Test; do
+            test_binary_name=$(basename $test_binary)
+            echo "Running Valgrind DHAT on $test_binary_name"
+            if [[ -n "${EXCLUDE_TESTS[$test_binary_name]}" ]]; then
+              exclude_pattern="${EXCLUDE_TESTS[$test_binary_name]}"
+              valgrind --tool=dhat --log-file="valgrind_logs/$test_binary_name_dhat.log" ./$test_binary --gtest_filter="$exclude_pattern" || true
+            else
+              valgrind --tool=dhat --log-file="valgrind_logs/$test_binary_name_dhat.log" ./$test_binary || true
+            fi
+
+            cat "valgrind_logs/$test_binary_name_dhat.log" >> valgrind_logs/valgrind_complete_dhat_log.log
+
+            if grep -q "ERROR SUMMARY: [^0]" "valgrind_logs/$test_binary_name_dhat.log"; then
+              echo "Valgrind DHAT errors found in $test_binary_name:"
+              grep -A1 "ERROR SUMMARY:" "valgrind_logs/$test_binary_name_dhat.log" >> valgrind_logs/valgrind_dhat_summary.log
+              echo "Valgrind DHAT log for $test_binary_name:"
+              cat "valgrind_logs/$test_binary_name_dhat.log"
+              echo "------------------------"
+            fi
+          done
+
+          echo "Valgrind DHAT Summary:"
+          cat valgrind_logs/valgrind_dhat_summary.log
+
+      - name: Upload Valgrind DHAT logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: valgrind-dhat-log
+          path: up-transport-zenoh-cpp/build/Release/valgrind_logs/valgrind_complete_dhat_log.log
   # NOTE: In GitHub repository settings, the "Require status checks to pass
   # before merging" branch protection rule ensures that commits are only merged
   # from branches where specific status checks have passed. These checks are
@@ -176,11 +465,7 @@ jobs:
   ci:
     name: CI status checks
     runs-on: ubuntu-latest
-    #needs: [build, test]
-    # NOTE tests are currently known failing. At this early stage, we will allow
-    # some PRs to merge without fixing those tests. This will be reverted in the
-    # near future.
-    needs: [build]
+    needs: [build, test, memcheck, threadcheck, helgrind, dhat]
     if: always()
     steps:
       - name: Check whether all jobs pass

--- a/.github/workflows/ci_conan_profile
+++ b/.github/workflows/ci_conan_profile
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=11
+os=Linux


### PR DESCRIPTION
Aligning the CI with that from up-cpp. Inlude the Valgrind checks, conan profile and pinning of the version. [Issue 80](https://github.com/eclipse-uprotocol/up-transport-zenoh-cpp/issues/80)