### PR TITLE
Resolve Clang-Tidy Warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
           database: compile_commands.json
-          version: 12
+          version: 13
 
       - name: Run linters on tests
         id: test-linter
@@ -176,7 +176,7 @@ jobs:
           style: 'file' # read .clang-format for configuration
           tidy-checks: '' # Read .clang-tidy for configuration
           database: compile_commands.json
-          version: 12
+          version: 13
 
       - name: Report lint failure
         if:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ up-transport-zenoh-cpp, follow the steps in the
 ### With Conan for dependencies
 
 ```
-cd up-client-zenoh-cpp
+cd up-transport-zenoh-cpp
 conan install . --build=missing
 cmake --preset conan-release
 cd build/Release

--- a/include/up-transport-zenoh-cpp/ThreadSafeMap.h
+++ b/include/up-transport-zenoh-cpp/ThreadSafeMap.h
@@ -1,3 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef UP_TRANSPORT_ZENOH_CPP_THREADSAFEMAP_H
+#define UP_TRANSPORT_ZENOH_CPP_THREADSAFEMAP_H
+
 #include <algorithm>
 #include <map>
 #include <mutex>
@@ -25,9 +39,8 @@ public:
 		Iterator it = map_.find(key);
 		if (it != map_.end()) {
 			return it->second;
-		} else {
-			return std::nullopt;
 		}
+		return std::nullopt;
 	}
 
 	template <typename Predicate>
@@ -36,12 +49,13 @@ public:
 		Iterator it = std::find_if(map_.begin(), map_.end(), pred);
 		if (it != map_.end()) {
 			return it->second;
-		} else {
-			return std::nullopt;
 		}
+		return std::nullopt;
 	}
 
 private:
 	MapType map_;
 	mutable std::mutex mutex_;
 };
+
+#endif  // UP_TRANSPORT_ZENOH_CPP_THREADSAFEMAP_H

--- a/include/up-transport-zenoh-cpp/ZenohUTransport.h
+++ b/include/up-transport-zenoh-cpp/ZenohUTransport.h
@@ -15,9 +15,7 @@
 #include <up-cpp/transport/UTransport.h>
 
 #include <filesystem>
-#include <mutex>
 #include <optional>
-#include <unordered_map>
 
 #define ZENOHCXX_ZENOHC
 #include <zenoh.hxx>
@@ -46,14 +44,14 @@ namespace uprotocol::transport {
 struct ZenohUTransport : public UTransport {
 	/// @brief Constructor
 	///
-	/// @param defaultUri Default Authority and Entity (as a UUri) for
+	/// @param default_uri Default Authority and Entity (as a UUri) for
 	///                   clients using this transport instance.
-	/// @param configFile Path to a configuration file containing the Zenoh
+	/// @param config_file Path to a configuration file containing the Zenoh
 	///                   transport configuration.
-	ZenohUTransport(const v1::UUri& defaultUri,
-	                const std::filesystem::path& configFile);
+	ZenohUTransport(const v1::UUri& default_uri,
+	                const std::filesystem::path& config_file);
 
-	virtual ~ZenohUTransport() = default;
+	~ZenohUTransport() override = default;
 
 protected:
 	/// @brief Send a message.
@@ -63,8 +61,7 @@ protected:
 	/// @returns * OKSTATUS if the payload has been successfully
 	///            sent (ACK'ed)
 	///          * FAILSTATUS with the appropriate failure otherwise.
-	[[nodiscard]] virtual v1::UStatus sendImpl(
-	    const v1::UMessage& message) override;
+	[[nodiscard]] v1::UStatus sendImpl(const v1::UMessage& message) override;
 
 	/// @brief Represents the callable end of a callback connection.
 	using CallableConn = typename UTransport::CallableConn;
@@ -81,7 +78,7 @@ protected:
 	///
 	/// @returns * OKSTATUS if the listener was registered successfully.
 	///          * FAILSTATUS with the appropriate failure otherwise.
-	[[nodiscard]] virtual v1::UStatus registerListenerImpl(
+	[[nodiscard]] v1::UStatus registerListenerImpl(
 	    CallableConn&& listener, const v1::UUri& source_filter,
 	    std::optional<v1::UUri>&& sink_filter) override;
 
@@ -93,7 +90,7 @@ protected:
 	/// @note The default implementation does nothing.
 	///
 	/// @param listener shared_ptr of the Connection that has been broken.
-	virtual void cleanupListener(CallableConn listener) override;
+	void cleanupListener(CallableConn listener) override;
 
 	static std::string toZenohKeyString(
 	    const std::string& default_authority_name, const v1::UUri& source,

--- a/lint/clang-format.sh
+++ b/lint/clang-format.sh
@@ -9,7 +9,7 @@ pushd -n "$PROJECT_ROOT"
 for f in **/*.h **/*.cpp; do
 	echo
 	echo "Checking file '$f'"
-	# NOTE: Using clang-format-12 in CI system, too
-	clang-format-12 -i "$f"
+	# NOTE: Using clang-format-13 in CI system, too
+	clang-format-13 -i "$f"
 done
 popd -n

--- a/src/ZenohUTransport.cpp
+++ b/src/ZenohUTransport.cpp
@@ -277,7 +277,7 @@ v1::UStatus ZenohUTransport::registerListenerImpl(
 	std::string zenoh_key = toZenohKeyString(getEntityUri().authority_name(),
 	                                         source_filter, sink_filter);
 
-	return registerPublishNotificationListener_(zenoh_key, listener);
+	return registerPublishNotificationListener_(zenoh_key, std::move(listener));
 }
 
 void ZenohUTransport::cleanupListener(CallableConn listener) {

--- a/src/ZenohUTransport.cpp
+++ b/src/ZenohUTransport.cpp
@@ -37,7 +37,7 @@ std::string ZenohUTransport::toZenohKeyString(
     const std::optional<v1::UUri>& sink) {
 	std::ostringstream zenoh_key;
 
-	auto writeUUri = [&](const v1::UUri& uuri) {
+	auto write_u_uri = [&](const v1::UUri& uuri) {
 		zenoh_key << "/";
 
 		// authority_name
@@ -74,10 +74,10 @@ std::string ZenohUTransport::toZenohKeyString(
 
 	zenoh_key << "up";
 
-	writeUUri(source);
+	write_u_uri(source);
 
 	if (sink.has_value()) {
-		writeUUri(*sink);
+		write_u_uri(*sink);
 	} else {
 		zenoh_key << "/{}/{}/{}/{}";
 	}
@@ -105,13 +105,13 @@ v1::UAttributes ZenohUTransport::attachmentToUAttributes(
 
 	if (attachment_vec.size() != 2) {
 		spdlog::error("attachmentToUAttributes: attachment size != 2");
-		// TODO: error report, exception?
+		// TODO(unknown) error report, exception?
 	}
 
 	if (attachment_vec[0].second.size() == 1) {
 		if (attachment_vec[0].second[0] != UATTRIBUTE_VERSION) {
 			spdlog::error("attachmentToUAttributes: incorrect version");
-			// TODO: error report, exception?
+			// TODO(unknown) error report, exception?
 		}
 	};
 	v1::UAttributes res;
@@ -166,8 +166,7 @@ std::optional<v1::UMessage> ZenohUTransport::sampleToUMessage(
 		    "sampleToUMessage: empty attachment, cannot read uAttributes");
 		return std::nullopt;
 	}
-	std::string payload(
-	    zenoh::ext::deserialize<std::string>(sample.get_payload()));
+	auto payload(zenoh::ext::deserialize<std::string>(sample.get_payload()));
 	message.set_payload(payload);
 
 	return message;
@@ -186,7 +185,7 @@ std::optional<v1::UMessage> ZenohUTransport::queryToUMessage(
 		return std::nullopt;
 	}
 	if (query.get_payload().has_value()) {
-		std::string payload(zenoh::ext::deserialize<std::string>(
+		auto payload(zenoh::ext::deserialize<std::string>(
 		    query.get_payload().value().get()));
 		message.set_payload(payload);
 	}
@@ -194,12 +193,12 @@ std::optional<v1::UMessage> ZenohUTransport::queryToUMessage(
 	return message;
 }
 
-ZenohUTransport::ZenohUTransport(const v1::UUri& defaultUri,
-                                 const std::filesystem::path& configFile)
-    : UTransport(defaultUri),
+ZenohUTransport::ZenohUTransport(const v1::UUri& default_uri,
+                                 const std::filesystem::path& config_file)
+    : UTransport(default_uri),
       session_(zenoh::Session::open(
-          std::move(zenoh::Config::from_file(configFile.string().c_str())))) {
-	// TODO: add to setup or remove
+          zenoh::Config::from_file(config_file.string()))) {
+	// TODO(unknown) add to setup or remove
 	spdlog::set_level(spdlog::level::debug);
 
 	spdlog::info("ZenohUTransport init");
@@ -211,10 +210,10 @@ v1::UStatus ZenohUTransport::registerPublishNotificationListener_(
 
 	// NOTE: listener is captured by copy here so that it does not go out
 	// of scope when this function returns.
-	auto on_sample = [this, listener](const zenoh::Sample& sample) mutable {
-		auto maybeMessage = sampleToUMessage(sample);
-		if (maybeMessage.has_value()) {
-			listener(maybeMessage.value());
+	auto on_sample = [listener](const zenoh::Sample& sample) mutable {
+		auto maybe_message = sampleToUMessage(sample);
+		if (maybe_message.has_value()) {
+			listener(maybe_message.value());
 		} else {
 			spdlog::error("on_sample: failed to retrieve uMessage");
 		}
@@ -225,7 +224,7 @@ v1::UStatus ZenohUTransport::registerPublishNotificationListener_(
 	auto subscriber = session_.declare_subscriber(
 	    zenoh_key, std::move(on_sample), std::move(on_drop));
 	subscriber_map_.emplace(listener, std::move(subscriber));
-	return v1::UStatus();
+	return {};
 }
 
 v1::UStatus ZenohUTransport::sendPublishNotification_(
@@ -250,7 +249,7 @@ v1::UStatus ZenohUTransport::sendPublishNotification_(
 		return uError(v1::UCode::INTERNAL, e.what());
 	}
 
-	return v1::UStatus();
+	return {};
 }
 
 // NOTE: Messages have already been validated by the base class. It does not

--- a/test/extra/PublisherSubscriberTest.cpp
+++ b/test/extra/PublisherSubscriberTest.cpp
@@ -17,10 +17,9 @@
 
 #include "up-transport-zenoh-cpp/ZenohUTransport.h"
 
-namespace {
-constexpr size_t num_publish_messages = 25;
+constexpr size_t NUM_PUBLISH_MESSAGES = 25;
 
-using namespace uprotocol;
+namespace uprotocol {
 
 constexpr std::string_view ZENOH_CONFIG_FILE = BUILD_REALPATH_ZENOH_CONF;
 
@@ -38,18 +37,21 @@ protected:
 	// Run once per execution of the test application.
 	// Used for setup of all tests. Has access to this instance.
 	PublisherSubscriberTest() { zenoh::init_log_from_env_or("error"); }
-	~PublisherSubscriberTest() = default;
 
 	// Run once per execution of the test application.
 	// Used only for global setup outside of tests.
 	static void SetUpTestSuite() {}
 	static void TearDownTestSuite() {}
+
+public:
+	~PublisherSubscriberTest() override = default;
 };
 
 v1::UUri makeUUri(uint16_t resource_id) {
+	constexpr uint32_t DEFAULT_UE_ID = 0x10001;
 	v1::UUri uuri;
 	uuri.set_authority_name(static_cast<std::string>("test0"));
-	uuri.set_ue_id((0x10001));
+	uuri.set_ue_id((DEFAULT_UE_ID));
 	uuri.set_ue_version_major(1);
 	uuri.set_resource_id(resource_id);
 	return uuri;
@@ -85,7 +87,7 @@ void ValidateMessages(std::queue<v1::UMessage>& rx_queue, size_t num_messages,
 
 // TODO(sashacmc): config generation
 
-TEST_F(PublisherSubscriberTest, SinglePubSingleSub) {
+TEST_F(PublisherSubscriberTest, SinglePubSingleSub) {  // NOLINT
 	auto transport = getTransport();
 
 	communication::Publisher pub(transport, makeUUri(TOPIC_URI),
@@ -103,7 +105,7 @@ TEST_F(PublisherSubscriberTest, SinglePubSingleSub) {
 	EXPECT_TRUE(maybe_sub);
 
 	if (maybe_sub) {
-		for (auto remaining = num_publish_messages; remaining > 0;
+		for (auto remaining = NUM_PUBLISH_MESSAGES; remaining > 0;
 		     --remaining) {
 			std::ostringstream message;
 			message << "Message number: " << remaining;
@@ -115,11 +117,11 @@ TEST_F(PublisherSubscriberTest, SinglePubSingleSub) {
 		}
 	}
 
-	ValidateMessages(rx_queue, num_publish_messages, "Message number: ");
+	ValidateMessages(rx_queue, NUM_PUBLISH_MESSAGES, "Message number: ");
 }
 
 // Single publisher, multiple subscribers (2) on the same topic.
-TEST_F(PublisherSubscriberTest, SinglePubMultipleSub) {
+TEST_F(PublisherSubscriberTest, SinglePubMultipleSub) {  // NOLINT
 	auto transport = getTransport();
 
 	communication::Publisher pub(transport, makeUUri(TOPIC_URI),
@@ -148,7 +150,7 @@ TEST_F(PublisherSubscriberTest, SinglePubMultipleSub) {
 	EXPECT_TRUE(maybe_sub2);
 
 	if (maybe_sub && maybe_sub2) {
-		for (auto remaining = num_publish_messages; remaining > 0;
+		for (auto remaining = NUM_PUBLISH_MESSAGES; remaining > 0;
 		     --remaining) {
 			std::ostringstream message;
 			message << "Message number: " << remaining;
@@ -160,12 +162,13 @@ TEST_F(PublisherSubscriberTest, SinglePubMultipleSub) {
 		}
 	}
 
-	ValidateMessages(rx_queue, num_publish_messages, "Message number: ");
-	ValidateMessages(rx_queue2, num_publish_messages, "Message number: ");
+	ValidateMessages(rx_queue, NUM_PUBLISH_MESSAGES, "Message number: ");
+	ValidateMessages(rx_queue2, NUM_PUBLISH_MESSAGES, "Message number: ");
 }
 
 // Single publisher, two subscribers on different topics
-TEST_F(PublisherSubscriberTest, SinglePubMultipleSubDifferentTopics) {
+TEST_F(PublisherSubscriberTest,  // NOLINT
+       SinglePubMultipleSubDifferentTopics) {
 	auto transport = getTransport();
 
 	communication::Publisher pub(transport, makeUUri(TOPIC_URI),
@@ -183,13 +186,13 @@ TEST_F(PublisherSubscriberTest, SinglePubMultipleSubDifferentTopics) {
 	EXPECT_TRUE(maybe_sub);
 
 	// subscribe to a different topic (non-existent topic)
-	auto on_rx2 = [](const v1::UMessage& message) { FAIL(); };
+	auto on_rx2 = [](const v1::UMessage& /*message*/) { FAIL(); };
 	auto maybe_sub2 = communication::Subscriber::subscribe(
 	    transport, makeUUri(TOPIC_URI2), std::move(on_rx2));
 	EXPECT_TRUE(maybe_sub2);
 
 	if (maybe_sub && maybe_sub2) {
-		for (auto remaining = num_publish_messages; remaining > 0;
+		for (auto remaining = NUM_PUBLISH_MESSAGES; remaining > 0;
 		     --remaining) {
 			std::ostringstream message;
 			message << "Message number: " << remaining;
@@ -201,11 +204,12 @@ TEST_F(PublisherSubscriberTest, SinglePubMultipleSubDifferentTopics) {
 		}
 	}
 
-	ValidateMessages(rx_queue, num_publish_messages, "Message number: ");
+	ValidateMessages(rx_queue, NUM_PUBLISH_MESSAGES, "Message number: ");
 }
 
 // Two publishers, two subscribers, two topics
-TEST_F(PublisherSubscriberTest, MultiplePubMultipleSubDifferentTopics) {
+TEST_F(PublisherSubscriberTest,  // NOLINT
+       MultiplePubMultipleSubDifferentTopics) {
 	auto transport = getTransport();
 
 	communication::Publisher pub(transport, makeUUri(TOPIC_URI),
@@ -236,7 +240,7 @@ TEST_F(PublisherSubscriberTest, MultiplePubMultipleSubDifferentTopics) {
 	EXPECT_TRUE(maybe_sub2);
 
 	if (maybe_sub && maybe_sub2) {
-		for (auto remaining = num_publish_messages; remaining > 0;
+		for (auto remaining = NUM_PUBLISH_MESSAGES; remaining > 0;
 		     --remaining) {
 			std::ostringstream message;
 			message << "Pub 1 - Message number: " << remaining;
@@ -254,10 +258,10 @@ TEST_F(PublisherSubscriberTest, MultiplePubMultipleSubDifferentTopics) {
 		}
 	}
 
-	ValidateMessages(rx_queue, num_publish_messages,
+	ValidateMessages(rx_queue, NUM_PUBLISH_MESSAGES,
 	                 "Pub 1 - Message number: ");
-	ValidateMessages(rx_queue2, num_publish_messages,
+	ValidateMessages(rx_queue2, NUM_PUBLISH_MESSAGES,
 	                 "Pub 2 - Message number: ");
 }
 
-}  // namespace
+}  // namespace uprotocol


### PR DESCRIPTION
This pull request addresses and resolves several Clang-Tidy warnings identified between numbers 97 and 103.

Closes #97 #98 #99 #100 #101 #102 #103 
